### PR TITLE
atree glob pattern support

### DIFF
--- a/atree/README.txt
+++ b/atree/README.txt
@@ -1,6 +1,65 @@
+atree - print a tree of asciidoc document inclusions
+
 syntax: atree file|directory
 
 Prints a tree of asciidoc document inclusions.
 
 First parameter is the top level file, or a directory with the file.
+
+
+OUTPUT
+------
+
+Included files are printed in order of appearance. Indentation shows the level of nesting. If the inclusion of a file is modified in some way, this is displayed:
+
+* If a file is included, but the inclusion is commented out, the line with the included path begins with the // characters, to idicate the file is included but does not affect output:
+
+  // this-is-a-commented-out-file.adoc
+
+* If a file is included, but the inclusion is altered by conditionals, an additional line is shown which explains the conditionals, such as:
+
+  modules/developer/con_hardening_c_cpp_code.adoc
+      \- !!!  ifndef::developer-book
+
+* If a file can not be read, its inclusion will be displayed, but no includes inside that file can be analyzed.
+
+
+EXAMPLE
+-------
+
+1. Clone the Fedora quick docs repository:
+
+   $ git clone https://pagure.io/fedora-docs/quick-docs.git
+
+2. Change to the directory with top-level AsciiDoc files:
+
+   $ cd quick-docs/modules/ROOT/pages
+
+3. Show tree of some of the files: 
+
+   $ atree securing-the-system-by-keeping-it-up-to-date.adoc
+   securing-the-system-by-keeping-it-up-to-date.adoc
+       {partialsdir}/con_why-it-is-important-keeping-your-system-up-to-date.adoc
+       {partialsdir}/proc_manual-updating-using-gui.adoc
+       {partialsdir}/proc_manual-updating-using-cli.adoc
+       {partialsdir}/proc_setting-automatic-updates.adoc
+
+
+KNOWN ISSUES
+------------
+
+* If an attribute is used in the include macro, the attribute is not uderstood and thus also not expanded. The include is displayed, but the actual file can not be loaded and thus any further inclusions are not shown.
+
+* Listing multiple files or directories is not supported.
+
+* 
+
+
+HINTS
+-----
+
+* If there is only a single AsciiDoc file in the directory, atree will assume that's the one you want analyzed, even if you do not specify it.
+
+* You can use egrep to add search and highlighting:
+  atree | egrep --color "SOME-FILE-I-WANT-HIGHLIGHTED|$"
 

--- a/atree/README.txt
+++ b/atree/README.txt
@@ -1,10 +1,13 @@
 atree - print a tree of asciidoc document inclusions
 
-syntax: atree file|directory
+syntax: atree file|directory [file|directory]...
 
 Prints a tree of asciidoc document inclusions.
 
-First parameter is the top level file, or a directory with the file.
+INPUT
+-----
+
+The only possible parameter is the top level file, or a directory with the file, or a glob pattern for these. You can add this parameter multiple times.
 
 
 OUTPUT
@@ -50,15 +53,15 @@ KNOWN ISSUES
 
 * If an attribute is used in the include macro, the attribute is not uderstood and thus also not expanded. The include is displayed, but the actual file can not be loaded and thus any further inclusions are not shown.
 
-* Listing multiple files or directories is not supported.
-
-* 
+* All includes in comments are listed, including these that are not intended as part of the document, but only comment.
 
 
 HINTS
 -----
 
 * If there is only a single AsciiDoc file in the directory, atree will assume that's the one you want analyzed, even if you do not specify it.
+
+* You can specify the input with glob patterns, including directory traversal /**/. This lets you construct very powerful queries.
 
 * You can use egrep to add search and highlighting:
   atree | egrep --color "SOME-FILE-I-WANT-HIGHLIGHTED|$"

--- a/atree/atree
+++ b/atree/atree
@@ -14,6 +14,7 @@ comment_finder = re.compile(r"(\/{4,})")
 ifdef_finder = re.compile(r"(\/\/)?.*((?:ifdef|ifndef|ifeval|endif)::[^\[]*)\[\]") # needs empty brackets at end = skips inline content
 
 do_debug = False
+indent_level = 4
 
 def dp(*var) :
   if do_debug :
@@ -81,15 +82,15 @@ class AFile :
   
   def print_tree(self, level=0) :
     if self.commented :
-      print(" "*2*level + "// " + self.fname)
+      print(" "*indent_level*level + "// " + self.fname)
     else :
-      print(" "*2*level + self.fname)
+      print(" "*indent_level*level + self.fname)
     cond = ""
     for s in self.conditions :
       if not s.startswith("//") :
         cond += " " + s
     if cond :
-      print(" "*2*(level+1) + "\\- !!! "+ cond)
+      print(" "*indent_level*(level+1) + "\\- !!! "+ cond)
     for subfile in self.includes :
       subfile.print_tree(level+1)
 

--- a/atree/atree
+++ b/atree/atree
@@ -4,7 +4,7 @@
 from __future__ import print_function
 import sys
 import re
-from os.path import dirname, basename, isfile, isdir, join, abspath
+from os.path import dirname, basename, isfile, isdir, join, abspath, exists
 from os import getcwd, chdir
 from glob import glob
 
@@ -33,6 +33,7 @@ class AFile :
     self.commented = False # this is in a comment
     self.recursive = False # this is a known infinite recursion
     self.invalid = False # this as an invalid path
+    self.nonexistent = False # this path does not exist
     self.includes = []
     self.conditions = []
     
@@ -47,10 +48,16 @@ class AFile :
     if self.invalid :
       debug_print("skipping: this is an invalid file name")
       return
+    if self.nonexistent :
+      debug_print("skipping: this is a nonexistent file name")
+      return
     this_path = dirname(self.fname)
     try :
       if self.parent_path :
         fn = join(self.parent_path, self.fname)
+        if not exists(fn) :
+          self.nonexistent = True
+          raise IOError("File does not exist, skipping.")
         f = open(fn, "r")
         debug_print("open() ", fn)
       else :
@@ -76,6 +83,7 @@ class AFile :
           if any((c in invalid_chars) for c in include[1]) :
             debug_print("marking as invalid due to weird characters in path")
             new_file.invalid = True
+          # exists/nonexistent can not work here because the true file name incl. dir must be constructed, but would be here otherwise
           # all this ^^^ is about determining status of the found include
           new_file.conditions = [i for i in stack]
           self.includes.append(new_file)
@@ -118,6 +126,8 @@ class AFile :
       warns += "R!"
     if self.invalid :
       warns += "X!"
+    if self.nonexistent :
+      warns += "N!"
     if warns :
       warns += " " # terminating space to make it readable
     if not (not display_commented and self.commented) :

--- a/atree/atree
+++ b/atree/atree
@@ -97,6 +97,7 @@ class AFile :
 
 def guess_file() :
   # see if there is master.adoc, index.adoc, or a single .adoc file, in that order, and return that file or empty string
+  debug_print("guess_file()")
   if isfile("master.adoc") :
     return "master.adoc"
   elif isfile("index.adoc") :
@@ -107,44 +108,71 @@ def guess_file() :
       return adocs[0]
   return ""
 
+
+def analyze_path(knownfile) :
+	# takes a path that is a known existing file under current situation
+	top = AFile(knownfile)
+	top.resolve()
+	top.print_tree()
+
+
+def process_path(somepath) :
+	debug_print("process_path()")
+	the_file = basename(somepath)
+	the_dir = dirname(somepath)
+	debug_print(somepath, "//", the_dir, "//", the_file)
+	# now handle when a directory is given instead of a file (must always guess then)
+	if the_dir and not the_file :
+		# if parameter is given like some/dir/ with trailing slash (eg. shell autocomplete)
+		chdir(the_dir)
+		the_file = guess_file()
+		if not the_file :
+			print("Could not guess an AsciiDoc file in directory %s" % (the_dir))
+		else :
+			analyze_path(the_file)
+	elif isdir(the_file) :
+		# if parameter is given as some/dir without trailing slash (eg. manually)
+		target = pjoin(the_dir,the_file)
+		chdir(target)
+		the_file = guess_file()
+		if not the_file :
+			print("Could not guess an AsciiDoc file in directory %s" % (target))
+			exit(1)
+		analyze_path(the_file)
+	elif the_dir :
+		# if parameter is given as some/dir/file.adoc and has a dir component
+		chdir(the_dir)
+		analyze_path(the_file)
+	else :
+		# if it's given as file.adoc with no directory
+		analyze_path(the_file)
+
+
+
 # MAIN
-
-# pick the file where to start
-the_file = ""
-the_dir = ""
-if len(sys.argv) >= 2 :
-  # called with parameter, which must be further processed
-  the_file = basename(sys.argv[1])
-  the_dir = dirname(sys.argv[1])
+curdir = getcwd()
+debug_print(sys.argv)
+if len(sys.argv) < 2 :
+	# called with no params, must guess the file
+	the_file = guess_file()
+	if not the_file :
+		# could not guess, let's fail
+		print("No parameters specified and no file found that you obviously wanted to be automagically guessed.")
+		exit(1)
+	else :
+		# found a default file
+		process_path(the_file)
 else :
-  # must guess the file
-  the_file = guess_file()
-  if not the_file :
-    # could not guess, let's fail
-    print("No AsciiDoc file specified and no file found that you obviously wanted to be automagically guessed.")
-    exit(1)
-
-debug_print(the_dir, "//", the_file)
-# now handle when a directory is given instead of a file (must always guess then)
-if the_dir and not the_file :
-  # if parameter is given like some/dir/ with shell autocomplete
-  chdir(the_dir)
-  the_file = guess_file()
-  if not the_file :
-    print("No AsciiDoc file specified and no file found that you obviously wanted to be automagically guessed.")
-    exit(1)
-elif isdir(the_file) :
-  # if parameter is given manually as some/dir
-  chdir(pjoin(the_dir,the_file))
-  the_file = guess_file()
-  if not the_file :
-    print("No AsciiDoc file specified and no file found that you obviously wanted to be automagically guessed.")
-    exit(1)
-elif the_dir :
-  chdir(the_dir)
-
-top = AFile(the_file)
-top.resolve()
-top.print_tree()
+	# called with exact params specifying files or dirs
+	items = sys.argv[1:]
+	debug_print(items)
+	nitems = len(items)
+	for i in range(nitems) :
+		item = items[i]
+		print("Listing %s:" % (item))
+		chdir(curdir)
+		process_path(item)
+		if i < nitems-1 :
+			print() # empty line
 
 # EOF

--- a/atree/atree
+++ b/atree/atree
@@ -4,8 +4,7 @@
 from __future__ import print_function
 import sys
 import re
-from os.path import dirname, basename, isfile, isdir
-from os.path import join as pjoin
+from os.path import dirname, basename, isfile, isdir, join, abspath
 from os import getcwd, chdir
 from glob import glob
 
@@ -15,12 +14,15 @@ ifdef_finder = re.compile(r"(\/\/)?.*((?:ifdef|ifndef|ifeval|endif)::[^\[]*)\[\]
 
 do_debug = False
 indent_level = 4
+invalid_chars = set("<>|*:")
 
 def debug_print(*var) :
   if do_debug :
     print(*var)
 
 stack = []
+display_commented = False
+analyze_commented = False
 
 class AFile :
   
@@ -28,17 +30,29 @@ class AFile :
     debug_print("AFile.__init__", fname, parent_path)
     self.fname = fname
     self.parent_path = parent_path
+    self.commented = False # this is in a comment
+    self.recursive = False # this is a known infinite recursion
+    self.invalid = False # this as an invalid path
     self.includes = []
-    self.commented = False
     self.conditions = []
     
   def resolve(self) :
-    debug_print("resolve()")
+    debug_print("resolve()", self.parent_path, self.fname)
+    if self.commented and not analyze_commented :
+      debug_print("skipping: commented and analyze_commented is off")
+      return
+    if self.recursive :
+      debug_print("skipping: this is self-recursively included")
+      return
+    if self.invalid :
+      debug_print("skipping: this is an invalid file name")
+      return
     this_path = dirname(self.fname)
     try :
       if self.parent_path :
-        f = open(self.parent_path + "/" + self.fname, "r")
-        debug_print("open() ", self.parent_path + "/" + self.fname)
+        fn = join(self.parent_path, self.fname)
+        f = open(fn, "r")
+        debug_print("open() ", fn)
       else :
         f = open(self.fname, "r")
         debug_print("open() ", self.fname)
@@ -46,23 +60,35 @@ class AFile :
       f.close()
       debug_print("read ok")
       for line in lines :
-        # see if there is include on this line
+        # iterate all file lines and act on what they are: comment, include, ifdef, sth else?
+        # one line can be realistically only one "thing" so order of processing does not matter
+        # vvv see if there is include on this line
         include_found = include_finder.findall(line)
         for include in include_found :
           debug_print("include::", include[1])
-          new_file = AFile(include[1], pjoin(self.parent_path, this_path))
+          include_real_dir = abspath(join(self.parent_path, this_path))
+          debug_print("real dir", include_real_dir)
+          new_file = AFile(include[1], include_real_dir)
           new_file.commented = new_file.commented or (include[0] == "//") or (stack and stack[-1].startswith("//")) or self.commented
-          # this ^^^ is about determining status of the found include
+          if (include_real_dir == self.parent_path) and (basename(include[1]) == self.fname) :
+            debug_print("marking as self-recursive due to apparent identity with parent file")
+            new_file.recursive = True
+          if any((c in invalid_chars) for c in include[1]) :
+            debug_print("marking as invalid due to weird characters in path")
+            new_file.invalid = True
+          # all this ^^^ is about determining status of the found include
           new_file.conditions = [i for i in stack]
           self.includes.append(new_file)
         # this vvv is about determining if a multiline comment starts or ends here (instead)
         comment_found = comment_finder.findall(line)
         for comment in comment_found :
           if stack and stack[-1] == comment :
+            debug_print("comment", comment, "pop")
             stack.pop()
           else :
+            debug_print("comment", comment, "push")
             stack.append(comment)
-        # see if there is a preprocessor condition
+        # vvv see if there is a preprocessor condition
         ifdef_found = ifdef_finder.findall(line)
         for ifdef in ifdef_found :
           if ifdef[0] != "//" : # is the condition not-commented out?
@@ -70,8 +96,11 @@ class AFile :
               stack.pop() # assumes there are no condition crossovers
             else :
               stack.append(ifdef[1])
-          # else: silently drop commented-out conditions
+          else:
+            # silently drop commented-out conditions
+            debug_print("dropped commented out " + ifdef[1])
     except Exception as e :
+      # expected to catch file exceptions
       debug_print("Exception caught for resolve()")
       debug_print("self.fname ", self.fname)
       debug_print("self.parent_path", self.parent_path)
@@ -81,16 +110,26 @@ class AFile :
       subfile.resolve()
   
   def print_tree(self, level=0) :
+    # first store any mods to the file listing
+    warns = ""
     if self.commented :
-      print(" "*indent_level*level + "// " + self.fname)
-    else :
-      print(" "*indent_level*level + self.fname)
+      warns += "//"
+    if self.recursive :
+      warns += "R!"
+    if self.invalid :
+      warns += "X!"
+    if warns :
+      warns += " " # terminating space to make it readable
+    if not (not display_commented and self.commented) :
+      # show in all cases except when comments are off and it's comment
+      print(" "*indent_level*level + warns + self.fname)
     cond = ""
     for s in self.conditions :
       if not s.startswith("//") :
         cond += " " + s
     if cond :
       print(" "*indent_level*(level+1) + "\\- !!! "+ cond)
+    # invalid, recursive etc. must not have any includes stored so safe to call it with no check
     for subfile in self.includes :
       subfile.print_tree(level+1)
 
@@ -110,42 +149,42 @@ def guess_file() :
 
 
 def analyze_path(knownfile) :
-	# takes a path that is a known existing file under current situation
-	top = AFile(knownfile)
-	top.resolve()
-	top.print_tree()
+  # takes a path that is a known existing file under current situation
+  top = AFile(knownfile)
+  top.resolve()
+  top.print_tree()
 
 
 def process_path(somepath) :
-	debug_print("process_path()")
-	the_file = basename(somepath)
-	the_dir = dirname(somepath)
-	debug_print(somepath, "//", the_dir, "//", the_file)
-	# now handle when a directory is given instead of a file (must always guess then)
-	if the_dir and not the_file :
-		# if parameter is given like some/dir/ with trailing slash (eg. shell autocomplete)
-		chdir(the_dir)
-		the_file = guess_file()
-		if not the_file :
-			print("Could not guess an AsciiDoc file in directory %s" % (the_dir))
-		else :
-			analyze_path(the_file)
-	elif isdir(the_file) :
-		# if parameter is given as some/dir without trailing slash (eg. manually)
-		target = pjoin(the_dir,the_file)
-		chdir(target)
-		the_file = guess_file()
-		if not the_file :
-			print("Could not guess an AsciiDoc file in directory %s" % (target))
-			exit(1)
-		analyze_path(the_file)
-	elif the_dir :
-		# if parameter is given as some/dir/file.adoc and has a dir component
-		chdir(the_dir)
-		analyze_path(the_file)
-	else :
-		# if it's given as file.adoc with no directory
-		analyze_path(the_file)
+  debug_print("process_path()")
+  the_file = basename(somepath)
+  the_dir = dirname(somepath)
+  debug_print(somepath, "//", the_dir, "//", the_file)
+  # now handle when a directory is given instead of a file (must always guess then)
+  if the_dir and not the_file :
+    # if parameter is given like some/dir/ with trailing slash (eg. shell autocomplete)
+    chdir(the_dir)
+    the_file = guess_file()
+    if not the_file :
+      print("Could not guess an AsciiDoc file in directory %s" % (the_dir))
+    else :
+      analyze_path(the_file)
+  elif isdir(the_file) :
+    # if parameter is given as some/dir without trailing slash (eg. manually)
+    target = join(the_dir,the_file)
+    chdir(target)
+    the_file = guess_file()
+    if not the_file :
+      print("Could not guess an AsciiDoc file in directory %s" % (target))
+      exit(1)
+    analyze_path(the_file)
+  elif the_dir :
+    # if parameter is given as some/dir/file.adoc and has a dir component
+    chdir(the_dir)
+    analyze_path(the_file)
+  else :
+    # if it's given as file.adoc with no directory
+    analyze_path(the_file)
 
 
 
@@ -153,31 +192,31 @@ def process_path(somepath) :
 curdir = getcwd()
 debug_print(sys.argv)
 if len(sys.argv) < 2 :
-	# called with no params, must guess the file
-	the_file = guess_file()
-	if not the_file :
-		# could not guess, let's fail
-		print("No parameters specified and no file found that you obviously wanted to be automagically guessed.")
-		exit(1)
-	else :
-		# found a default file
-		process_path(the_file)
+  # called with no params, must guess the file
+  the_file = guess_file()
+  if not the_file :
+    # could not guess, let's fail
+    print("No parameters specified and no file found that you obviously wanted to be automagically guessed.")
+    exit(1)
+  else :
+    # found a default file
+    process_path(the_file)
 else :
-	# called with exact params specifying globs for files or dirs 
-	items = sys.argv[1:]
-	debug_print(items)
-	finds = []
-	for item in items :
-		found = glob(item)
-		finds += found
-	debug_print(finds)
-	nitems = len(finds)
-	for i in range(nitems) :
-		item = finds[i]
-		print("Listing %s:" % (item))
-		chdir(curdir)
-		process_path(item)
-		if i < nitems-1 :
-			print() # empty line
+  # called with exact params specifying globs for files or dirs 
+  items = sys.argv[1:]
+  debug_print(items)
+  finds = []
+  for item in items :
+    found = glob(item)
+    finds += found
+  debug_print(finds)
+  nitems = len(finds)
+  for i in range(nitems) :
+    item = finds[i]
+    print("Listing %s:" % (item))
+    chdir(curdir)
+    process_path(item)
+    if i < nitems-1 :
+      print() # empty line
 
 # EOF

--- a/atree/atree
+++ b/atree/atree
@@ -163,12 +163,17 @@ if len(sys.argv) < 2 :
 		# found a default file
 		process_path(the_file)
 else :
-	# called with exact params specifying files or dirs
+	# called with exact params specifying globs for files or dirs 
 	items = sys.argv[1:]
 	debug_print(items)
-	nitems = len(items)
+	finds = []
+	for item in items :
+		found = glob(item)
+		finds += found
+	debug_print(finds)
+	nitems = len(finds)
 	for i in range(nitems) :
-		item = items[i]
+		item = finds[i]
 		print("Listing %s:" % (item))
 		chdir(curdir)
 		process_path(item)

--- a/atree/atree
+++ b/atree/atree
@@ -16,7 +16,7 @@ ifdef_finder = re.compile(r"(\/\/)?.*((?:ifdef|ifndef|ifeval|endif)::[^\[]*)\[\]
 do_debug = False
 indent_level = 4
 
-def dp(*var) :
+def debug_print(*var) :
   if do_debug :
     print(*var)
 
@@ -25,7 +25,7 @@ stack = []
 class AFile :
   
   def __init__(self, fname, parent_path="") :
-    dp("AFile.__init__", fname, parent_path)
+    debug_print("AFile.__init__", fname, parent_path)
     self.fname = fname
     self.parent_path = parent_path
     self.includes = []
@@ -33,23 +33,23 @@ class AFile :
     self.conditions = []
     
   def resolve(self) :
-    dp("resolve()")
+    debug_print("resolve()")
     this_path = dirname(self.fname)
     try :
       if self.parent_path :
         f = open(self.parent_path + "/" + self.fname, "r")
-        dp("open() ", self.parent_path + "/" + self.fname)
+        debug_print("open() ", self.parent_path + "/" + self.fname)
       else :
         f = open(self.fname, "r")
-        dp("open() ", self.fname)
+        debug_print("open() ", self.fname)
       lines = f.readlines()
       f.close()
-      dp("read ok")
+      debug_print("read ok")
       for line in lines :
         # see if there is include on this line
         include_found = include_finder.findall(line)
         for include in include_found :
-          dp("include::", include[1])
+          debug_print("include::", include[1])
           new_file = AFile(include[1], pjoin(self.parent_path, this_path))
           new_file.commented = new_file.commented or (include[0] == "//") or (stack and stack[-1].startswith("//")) or self.commented
           # this ^^^ is about determining status of the found include
@@ -72,11 +72,11 @@ class AFile :
               stack.append(ifdef[1])
           # else: silently drop commented-out conditions
     except Exception as e :
-      dp("Exception caught for resolve()")
-      dp("self.fname ", self.fname)
-      dp("self.parent_path", self.parent_path)
-      dp("curdir ", getcwd())
-      dp("error ", e)
+      debug_print("Exception caught for resolve()")
+      debug_print("self.fname ", self.fname)
+      debug_print("self.parent_path", self.parent_path)
+      debug_print("curdir ", getcwd())
+      debug_print("error ", e)
     for subfile in self.includes :
       subfile.resolve()
   
@@ -124,7 +124,7 @@ else :
     print("No AsciiDoc file specified and no file found that you obviously wanted to be automagically guessed.")
     exit(1)
 
-dp(the_dir, "//", the_file)
+debug_print(the_dir, "//", the_file)
 # now handle when a directory is given instead of a file (must always guess then)
 if the_dir and not the_file :
   # if parameter is given like some/dir/ with shell autocomplete


### PR DESCRIPTION
This adds support for listing multiple doc trees incl. glob pattern support to atree.

This should now be possible:
atree some-file.adoc titles/**/master.adoc some/path/index.adoc