### PR TITLE
Add vale to package list

### DIFF
--- a/dotfiles/Brewfile
+++ b/dotfiles/Brewfile
@@ -17,6 +17,7 @@ brew 'podman'
 brew 'asciidoctor'
 brew 'ruby'
 brew 'brew-gem'
+brew 'vale'
 
 # install whole applications aka 'brew install --cask'
 cask 'atom'


### PR DESCRIPTION
This PR adds `brew vale`, which is one of the preferred ways of installing [Vale](https://redhat-documentation.github.io/vale-at-red-hat/docs/user-guide/introduction/) for writers